### PR TITLE
DOCS Correct name for crewrecruitList.ejs

### DIFF
--- a/views/crewrecruitList.ejs
+++ b/views/crewrecruitList.ejs
@@ -51,7 +51,7 @@
                 <table border="1">
                     <thead class="tabtitle">
                         <td>num</td>
-                        <td>동아리 모집글명</td>
+                        <td>동아리 모집글 제목</td>
                     </thead>
                     <tbody>
                         <% num = 1; %>


### PR DESCRIPTION

Change the name of the topic from '동아리 모집글명' to '동아리 모집글 제목'.

Since it is hard for users to know if it is talking about club's name or
club's recruiting title, I thought it would be better to change the name.

Using '동아리 모집글 제목' will give better understanding to both crews
and participants.